### PR TITLE
chore: skip APIScan to prevent duplicate results

### DIFF
--- a/build/main.yml
+++ b/build/main.yml
@@ -34,6 +34,8 @@ extends:
           - script: npm run downloadBinaries
             displayName: Download Binaries
 
+        # The relevant files are already scanned elsewhere
+        skipApiScan: true
         apiScanSoftwareName: 'vscode-zeromq'
         apiScanSoftwareVersion: '0.2'
 


### PR DESCRIPTION
I have confirmed that the binaries are already scanned in the microsoft/zeromq-prebuilt pipeline.