### PR TITLE
fix: upstream file names changed

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -29,6 +29,7 @@ module.exports.download = async (opts) => {
     throw new Error("no prebuilds folder in vscode-zeromq");
   }
 
+  /** @type Set<string> */
   const foldersToCreate = new Set();
   prebuildFolders.forEach((folder) => {
     foldersToCreate.add(path.join(opts.destination, folder));
@@ -43,6 +44,7 @@ module.exports.download = async (opts) => {
     )
   );
 
+  /** @type string[] */
   const filesToCopy = [];
   await Promise.all(
     prebuildFolders.map(async (prebuildFolder) => {
@@ -53,8 +55,9 @@ module.exports.download = async (opts) => {
   // Copy the files across.
   await Promise.all(
     filesToCopy.map((file) => {
+      const newFileName = file.includes("zeromq.") ? file.replaceAll("zeromq.", "node.napi.") : file;
       console.info(
-        `Copying file ${file} from ${prebuildRoot} to ${opts.destination}`
+        `Copying file ${file} from ${prebuildRoot} to ${path.join(opts.destination, path.basename(newFileName))}`
       );
       return fsCopyFile(
         path.join(prebuildRoot, file),


### PR DESCRIPTION
This PR renames `zeromq.*` files back to `node.napi.*` for Jupyter.