### PR TITLE
chore: re-enable APIScan

### DIFF
--- a/build/main.yml
+++ b/build/main.yml
@@ -34,8 +34,6 @@ extends:
           - script: npm run downloadBinaries
             displayName: Download Binaries
 
-        # The relevant files are already scanned elsewhere
-        skipApiScan: true
         apiScanSoftwareName: 'vscode-zeromq'
         apiScanSoftwareVersion: '0.2'
 


### PR DESCRIPTION
Re-enables APIScan considering that the zeromq-prebuilt pipeline now publishes symbols.