### PR TITLE
chore: bump zeromq-prebuilt to 16.0.0-beta.16.13

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,6 +1,6 @@
 # Steps to publish a new version
 
 * Update the `VERSION` in `prePublish.js` file
-  * This is the version of the file(s) downloaded from https://github.com/microsoft/zeromq-prebuilt/releases/tag/16.0.0-beta.16.12
+  * This is the version of the file(s) downloaded from https://github.com/microsoft/zeromq-prebuilt/releases/tag/16.0.0-beta.16.13
 * Bump the version in package.json
 * Run the pipeline https://dev.azure.com/monacotools/Monaco/_build?definitionId=469&_a=summary and ensure to tick the box `Publish @vscode/vscode-zeromq`

--- a/build/main.yml
+++ b/build/main.yml
@@ -34,6 +34,7 @@ extends:
           - script: npm run downloadBinaries
             displayName: Download Binaries
 
+        apiScanDependentPipelineId: '466' # zeromq-prebuilt
         apiScanExcludes: 'package/prebuilds/win32-arm64/**/*.*'
         apiScanSoftwareName: 'vscode-zeromq'
         apiScanSoftwareVersion: '0.2'

--- a/build/main.yml
+++ b/build/main.yml
@@ -34,7 +34,6 @@ extends:
           - script: npm run downloadBinaries
             displayName: Download Binaries
 
-        apiScanDependentPipelineId: '466' # zeromq-prebuilt
         apiScanExcludes: 'package/prebuilds/win32-arm64/**/*.*'
         apiScanSoftwareName: 'vscode-zeromq'
         apiScanSoftwareVersion: '0.2'

--- a/build/prePublish.js
+++ b/build/prePublish.js
@@ -7,7 +7,7 @@ const path = require("path");
 const { download } = require("./download");
 const fs = require("fs");
 
-const VERSION = "16.0.0-beta.16.12";
+const VERSION = "16.0.0-beta.16.13";
 
 /**
  * Downloads the ZMQ binaries.


### PR DESCRIPTION
Brings in the latest engineering changes including revised symbol publishing. This PR is for internal compliance purposes.