### PR TITLE
chore: work around missing symbols scan result

### DIFF
--- a/build/main.yml
+++ b/build/main.yml
@@ -34,6 +34,7 @@ extends:
           - script: npm run downloadBinaries
             displayName: Download Binaries
 
+        apiScanDependentPipelineId: '466' # zeromq-prebuilt
         apiScanExcludes: 'package/prebuilds/win32-arm64/**/*.*'
         apiScanSoftwareName: 'vscode-zeromq'
         apiScanSoftwareVersion: '0.2'


### PR DESCRIPTION
The fix in #40 did not work as-is.
This PR registers zeromq-prebuilt as a dependent pipeline so that the engineering pipeline could download an exact artifact from that pipeline for APIScan to use.