### PR TITLE
chore: delete symbol files

### DIFF
--- a/build/download.js
+++ b/build/download.js
@@ -259,6 +259,24 @@ async function downloadAssetFromGithubApi(opts, asset) {
 
     throw e;
   }
+
+  console.log("Deleting symbol files");
+  try {
+    const files = fs.readdirSync(assetDestinationPath);
+    for (const file of files) {
+      if (file.endsWith(".pdb")) {
+        const curFilePath = path.join(assetDestinationPath, file);
+        console.info(`Deleting file ${curFilePath}`);
+        fs.unlinkSync(curFilePath);
+      }
+    }
+  } catch (e) {
+    console.log("Deleting invalid download");
+    await fsUnlink(assetDownloadFile).catch(() => {});
+    await fsRmdir(assetDestinationPath, { recursive: true }).catch(() => {});
+    
+    throw e;
+  }
 }
 
 /**


### PR DESCRIPTION
I forgot to add this step. zeromq-prebuilt now includes Windows PDB files in the GitHub release so that we can use them to analyze crash dumps if needed. However, vscode-jupyter, which uses vscode-zeromq, does not need the PDB file. Removing the PDB file as part of the download function prevents us from adding several megabytes to vscode-jupyter.